### PR TITLE
Add docker-compose with postgres and redis

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+.pnpm
+.pnpm-global
+.git
+.gitignore
+*.log
+.next
+out
+dist
+build
+.turbo
+.vscode
+.env
+.env.*
+coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:18
+
+WORKDIR /app
+
+# Install pnpm
+RUN corepack enable && corepack prepare pnpm@9.0.0 --activate
+
+# Copy manifest files first for caching
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+
+# Copy apps and packages
+COPY apps ./apps
+COPY packages ./packages
+
+RUN pnpm install --frozen-lockfile
+
+RUN pnpm build
+
+CMD ["pnpm", "dev"]

--- a/README.md
+++ b/README.md
@@ -50,6 +50,26 @@ cd my-turborepo
 pnpm dev
 ```
 
+## Docker
+
+Build a local development image with:
+
+```bash
+docker build -t slack-clone .
+```
+
+Run the container:
+
+```bash
+docker run --env-file .env -p 3000:3000 slack-clone
+```
+
+Start all services with Docker Compose:
+
+```bash
+docker compose up --build
+```
+
 ### Remote Caching
 
 > [!TIP]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    env_file:
+      - .env
+    ports:
+      - "3000:3000"
+    depends_on:
+      - postgres
+      - redis
+
+  postgres:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: slack
+      POSTGRES_PASSWORD: slack
+      POSTGRES_DB: slack
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    volumes:
+      - redis-data:/data
+    ports:
+      - "6379:6379"
+
+volumes:
+  postgres-data:
+  redis-data:


### PR DESCRIPTION
## Summary
- add docker-compose.yml with postgres and redis services
- document docker compose usage

## Testing
- `npm run lint` *(fails: turbo not found)*
- `npm run test` *(fails: Missing script)*
- `npm run test:coverage` *(fails: Missing script)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6843cb8bc4e88321848f3a24c1841976