### PR TITLE
Add test scripts and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ cd my-turborepo
 pnpm dev
 ```
 
+### Test
+
+To run all tests in the monorepo, use:
+
+```
+cd my-turborepo
+pnpm test
+```
+
+Generate a coverage report with:
+
+```
+pnpm test:coverage
+```
+
 ### Remote Caching
 
 > [!TIP]

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
-    "check-types": "turbo run check-types"
+    "check-types": "turbo run check-types",
+    "test": "turbo run test",
+    "test:coverage": "turbo run test:cov"
   },
   "devDependencies": {
     "prettier": "^3.5.3",


### PR DESCRIPTION
## Purpose
- add root scripts for running tests and coverage
- document new commands in README

## Testing
- `pnpm lint` *(fails: command not found)*
- `pnpm test` *(fails: command not found)*
- `pnpm test:coverage` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

## Checklist
- [ ] Code passes lint
- [ ] Tests written and pass
- [ ] Coverage maintained ≥ 90%
- [ ] Programmatic checks run and pass

------
https://chatgpt.com/codex/tasks/task_e_6843e94ad11c8321ab22e4275cca74e1